### PR TITLE
Changed return type to Integer instead of String

### DIFF
--- a/arcbees-facebook/src/main/java/com/arcbees/facebook/client/AuthResponse.java
+++ b/arcbees-facebook/src/main/java/com/arcbees/facebook/client/AuthResponse.java
@@ -30,11 +30,11 @@ public class AuthResponse extends JavaScriptObject {
     }
   }-*/;
 
-  public final native String getExpiresIn() /*-{
+  public final native Integer getExpiresIn() /*-{
     if (this.authResponse) {
       return this.authResponse.expiresIn;
     } else {
-      return "";
+      return 0;
     }    
   }-*/;
 


### PR DESCRIPTION
The expiresIn is a number representing the access_token's life. It is expressed in seconds, e.g.: 3600 for 1 hour. It is a number, not a String.
