### PR TITLE
Add the possibility to retrieve the email from the Facebook API

### DIFF
--- a/arcbees-facebook/src/main/java/com/arcbees/facebook/client/AuthResponse.java
+++ b/arcbees-facebook/src/main/java/com/arcbees/facebook/client/AuthResponse.java
@@ -28,7 +28,7 @@ public class AuthResponse extends JavaScriptObject {
     } else {
       return "";
     }
-  }-*/;
+  }-*/; 
 
   public final native Integer getExpiresIn() /*-{
     if (this.authResponse) {
@@ -36,7 +36,7 @@ public class AuthResponse extends JavaScriptObject {
     } else {
       return 0;
     }
-  }-*/;
+  }-*/; 
 
   public final native String getSignedRequest() /*-{
     if (this.authResponse) {
@@ -44,7 +44,7 @@ public class AuthResponse extends JavaScriptObject {
     } else {
       return "";
     }
-  }-*/;
+  }-*/; 
 
   public final native String getUserId() /*-{
     if (this.authResponse) {
@@ -52,11 +52,11 @@ public class AuthResponse extends JavaScriptObject {
     } else {
       return "";
     }
-  }-*/;
+  }-*/; 
 
   public final native Status getStatus() /*-{
     return @com.arcbees.facebook.client.Status::valueOf(Lcom/google/gwt/core/client/JavaScriptObject;)(this);
-  }-*/;
+  }-*/; 
 
     public final native String getEmail() /*-{
         if (this.authResponse) {
@@ -64,5 +64,5 @@ public class AuthResponse extends JavaScriptObject {
         } else {
             return "";
         }
-    }-*/;
+    }-*/; 
 }


### PR DESCRIPTION
I'm not sure if that's the right way to do it or if there is something else that's needed, but in another project, I would need the email associated with the FB account (we requested the permission for the email).
